### PR TITLE
Issue #60: Aggr Argument Confusion

### DIFF
--- a/src/table.js
+++ b/src/table.js
@@ -711,11 +711,14 @@ Table.normaliseAggr = function(aggr) {
   if (!aggr.func) {
     aggr = {func: aggr};
   }
-  aggr.args = aggr.args || [];
-  if (!Array.isArray(aggr.args)) {
-  	aggr.args = [aggr.args];
+  if (!aggr.func.initialize) {
+  	aggr.func = new aggr.func;
   }
-  aggr.args = aggr.args.map(arg => Table.normaliseExpr(arg));
+  aggr.func.args = aggr.func.args || [];
+  if (!Array.isArray(aggr.func.args)) {
+  	aggr.func.args = [aggr.func.args];
+  }
+  aggr.func.args = aggr.func.args.map(arg => Table.normaliseExpr(arg));
 
   aggr.as = aggr.as || aggr.func.constructor.name;
 
@@ -743,10 +746,10 @@ Table.prototype.groupby = function(groups, aggrs) {
   }
   groups = groups.map(group => Table.normaliseBinding(group));
 
+  aggrs = aggrs || [];
   if (aggrs && !Array.isArray(aggrs)) {
     aggrs = [aggrs,];
   }
-  aggrs = aggrs || [];
   aggrs = aggrs.map(aggr => Table.normaliseAggr(aggr));
 
   const that = this;

--- a/test/test_groupby.js
+++ b/test/test_groupby.js
@@ -61,6 +61,15 @@ describe('Table', function() {
     	expect(actual.namespace.family.data).to.deep.equal(["Flintstone", "Rubble"]);
     	expect(actual.namespace.CountStar.data).to.deep.equal([3, 3]);
   	});
+    it('should normalise anonymous aggregate classes', function() {
+    	const actual = Table
+    		.fromRows(bedrock)
+    		.groupBy([{expr: new RefExpr("last"), as: "family"}], CountStar);
+    	expect(actual.ordinals).to.deep.equal(["family", "CountStar"]);
+    	expect(actual.namespace).to.have.keys(actual.ordinals);
+    	expect(actual.namespace.family.data).to.deep.equal(["Flintstone", "Rubble"]);
+    	expect(actual.namespace.CountStar.data).to.deep.equal([3, 3]);
+  	});
     it('should compute aggregates with inputs', function() {
     	const actual = Table
     		.fromRows(bedrock)


### PR DESCRIPTION
The arguments to an aggregate are now part of the object, not the spec object.
Check whether the aggregate is a class or an Aggr object and call new for the former.